### PR TITLE
Skip pydot dependency on RPM releases

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -112,6 +112,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
+      --skip-keys python3-pydot
     devel_branch: galactic-devel
     last_version: 2.0.0
     name: upstream


### PR DESCRIPTION
This package is not currently available for the only RPM distribution we're targeting, RHEL 7. The dependency will have to be installed manually using pip. As a Python dependency, the absence of this dependency shouldn't affect our ability to build downstream packages.

This PR should be held until ros-infrastructure/bloom#604 is merged, since the action list will be changed at that time.